### PR TITLE
Adding Custom CUrlClient to make api response more frendly.

### DIFF
--- a/Examples/example.php
+++ b/Examples/example.php
@@ -11,14 +11,15 @@ use Fasodev\Sdk\OMSDK;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $result = OMSDK::init("username", "password", "merchantNumber", OMSDK::ENV_DEV)
-    ->setAmount(1000)//Montant de la transaction
-    ->setOTPCode(121212)//Code otp fourni par l'utilisateur
-    ->setClientNumber(76819212)//Le numero de client
-    ->processPayment()//Enclenchement du processus de paiement
+    ->setAmount(1000) // Montant de la transaction
+    ->setOTPCode(121212) // Code otp fourni par l'utilisateur
+    ->setClientNumber(76819212) // Le numero de client
+    ->processPayment() // Enclenchement du processus de paiement
 ;
 
 if ($result->status === 200) {
-    echo " paiement effectuée";
+
+    echo "paiement effectué";
     echo $result->transID;
 
 } else {

--- a/Examples/example2.php
+++ b/Examples/example2.php
@@ -11,12 +11,12 @@ use Fasodev\Sdk\OMSDK;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $orangeMoney = OMSDK::init("username", "password", "merchantNumber", OMSDK::ENV_DEV)
-    ->setAmount(1000)//Montant de la transaction
-    ->setOTPCode(121212)//Code otp fourni par l'utilisateur
-    ->setClientNumber(76819212)//Le numero de client
+    ->setAmount(1000) // Montant de la transaction
+    ->setOTPCode(121212) // Code otp fourni par l'utilisateur
+    ->setClientNumber(76819212)// Le numero de client
 ;
 $result = $orangeMoney
-    ->processPayment()//Enclenchement du processus de paiement
+    ->processPayment() // Enclenchement du processus de paiement
 ;
 if ($result->status === 200) {
     echo " paiement effectuée";

--- a/src/Fasodev/CUrl/CurlClient.php
+++ b/src/Fasodev/CUrl/CurlClient.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace App\CUrl;
+
+
+class CurlClient
+{
+    public function request($url, $content, $contentType = "Content-type: text/xml", $timeOut = 15){
+
+        $header[] = $contentType;
+        $header[] = "Content-length: ".strlen($content);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeOut);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $content);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+
+        $data = curl_exec($ch);
+
+        $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $Rheader = substr($data, 0, $header_size);
+        $body = substr($data, $header_size);
+        $error = curl_error ( $ch );
+        $erno = curl_errno($ch);
+
+        curl_close($ch);
+
+        $curlResponseData = [
+            'body'      => "<response>" . $body . "</response>",
+            'erno'      => $erno,
+            'error'     => $error,
+            'header'    => $Rheader
+        ];
+
+        return new RawCUrlResponse($curlResponseData);
+    }
+
+}
+
+

--- a/src/Fasodev/CUrl/RawCUrlResponse.php
+++ b/src/Fasodev/CUrl/RawCUrlResponse.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\CUrl;
+
+/**
+ * Class RawCUrlResponse
+ * @package App\CUrl
+ */
+class RawCUrlResponse
+{
+    private $header;
+    private $content;
+    private $erno;
+    private $error;
+
+    public function __construct(array $data)
+    {
+        $this->header   = isset($data['header']) ? $data['header'] : null;
+        $this->content  = isset($data['body']) ? $data['body'] : null;
+        $this->erno     = isset($data['erno']) ? $data['erno'] : null;
+        $this->error    = isset($data['error']) ? $data['error'] : null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHeader(): ?string
+    {
+        return $this->header;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Different de 0 si la requête n'aboutit pas par exemple probleme réseau ou refus de connexion de la par du serveur
+     * @return mixed
+     */
+    public function getErno()
+    {
+        return $this->erno;
+    }
+
+    /**
+     * L'erreur compter par <b>erno</b>
+     * @return mixed
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+}

--- a/src/Fasodev/Sdk/OMSDK.php
+++ b/src/Fasodev/Sdk/OMSDK.php
@@ -94,19 +94,19 @@ class OMSDK implements TransactionInterface
 
         $xml = "<?xml version='1.0' encoding='UTF-8'?>
         <COMMAND>
-        <TYPE>OMPREQ</TYPE>
-        <customer_msisdn>{$this->clientNumber}</customer_msisdn>
-        <merchant_msisdn>{$this->merchantNumber}</merchant_msisdn>
-        <api_username>{$this->username}</api_username>
-        <api_password>{$this->password}</api_password>
-        <amount>{$this->amount}</amount>
-        <PROVIDER>101</PROVIDER>
-        <PROVIDER2>101</PROVIDER2>
-        <PAYID>12</PAYID>
-        <PAYID2>12</PAYID2>
-        <otp>{$this->otp}</otp>
-        <reference_number>{$this->referenceNumber}</reference_number>
-        <ext_txn_id>201500068544</ext_txn_id>
+            <TYPE>OMPREQ</TYPE>
+            <customer_msisdn>{$this->clientNumber}</customer_msisdn>
+            <merchant_msisdn>{$this->merchantNumber}</merchant_msisdn>
+            <api_username>{$this->username}</api_username>
+            <api_password>{$this->password}</api_password>
+            <amount>{$this->amount}</amount>
+            <PROVIDER>101</PROVIDER>
+            <PROVIDER2>101</PROVIDER2>
+            <PAYID>12</PAYID>
+            <PAYID2>12</PAYID2>
+            <otp>{$this->otp}</otp>
+            <reference_number>{$this->referenceNumber}</reference_number>
+            <ext_txn_id>201500068544</ext_txn_id>
         </COMMAND>";
 
         $ch = curl_init();
@@ -117,6 +117,7 @@ class OMSDK implements TransactionInterface
         curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);
         $result = curl_exec($ch);
         curl_close($ch);
+
         return $result;
     }
 


### PR DESCRIPTION
Hello ! I have created utils that will help us to handle API responses with errors cases : 

or example if the request is unsuccessful due to a network problem or some other problem the **`erno`** and **`error`** attribute can tell us what happened. So by testing, if **erno** is 0 it means that everything went well even if OM side did not work for that status and message of **`content`** attribute (after content decode)  can tell us more about the error that OM sends back to us for example bad OTP. an example

`$response = $curlClient->request($url, $content);

 if ($response->getErno()){
       echo $response->getError();
 }

// Decode $response->getContent();  to stdClass or to an array  and read status code and the OM message.`

I've not used it in the original code yet I am expecting your comments and recommendations.

Thanks! 