### PR TITLE
fix: add support for external reference error

### DIFF
--- a/src/Http/RequestBody.php
+++ b/src/Http/RequestBody.php
@@ -25,7 +25,7 @@ class RequestBody
             <PAYID2>12</PAYID2>
             <otp>{$transactionData->getOtp()}</otp>
             <reference_number>{$transactionData->getReferenceNumber()}</reference_number>
-            <ext_txn_id>201500068544</ext_txn_id>
+            <ext_txn_id>{$transactionData->getExternalReference()}</ext_txn_id>
         </COMMAND>";
     }
 }

--- a/src/Sdk/Config/TransactionData.php
+++ b/src/Sdk/Config/TransactionData.php
@@ -14,17 +14,19 @@ class TransactionData
 
     protected string $otp;
 
+    protected string $externalReference;
 
-    private function __construct(string $clientNumber, string $paymentAmount, string $otp)
+    private function __construct(string $clientNumber, string $paymentAmount, string $otp, string $externalReference)
     {
         $this->otp = $otp;
         $this->paymentAmount = $paymentAmount;
         $this->clientNumber = $clientNumber;
+        $this->externalReference = $externalReference;
     }
 
-    public static function from(string $clientNumber, string $paymentAmount, string $otp): self
+    public static function from(string $clientNumber, string $paymentAmount, string $otp, string $externalReference): self
     {
-        return new self($clientNumber, $paymentAmount, $otp);
+        return new self($clientNumber, $paymentAmount, $otp, $externalReference);
     }
 
     /**
@@ -99,4 +101,19 @@ class TransactionData
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getExternalReference(): string
+    {
+        return $this->externalReference;
+    }
+
+    /**
+     * @param string $externalReference
+     */
+    public function setExternalReference(string $externalReference): void
+    {
+        $this->externalReference = $externalReference;
+    }
 }

--- a/src/Sdk/OrangeMoneyAPI.php
+++ b/src/Sdk/OrangeMoneyAPI.php
@@ -22,7 +22,7 @@ use Fasodev\Sdk\Exception\TransactionException;
 class OrangeMoneyAPI implements TransactionInterface
 {
     protected const DEV_API_URL = "https://testom.orange.bf:9008/payment";
-    protected const PROD_API_URL = "https://apiom.orange.bf:9007/payment";
+    protected const PROD_API_URL = "https://apiom.orange.bf";
 
     protected TransactionData $transactionData;
 
@@ -89,6 +89,12 @@ class OrangeMoneyAPI implements TransactionInterface
     public function withCustomReference(string $reference): self
     {
         $this->transactionData->setReferenceNumber($reference);
+        return $this;
+    }
+
+    public function withExternalReference(string $externalReference): self
+    {
+        $this->transactionData->setExternalReference($externalReference);
         return $this;
     }
 


### PR DESCRIPTION
This fix addresses an issue that arose after Orange updated their API, requiring users to provide an external reference. Please note that this reference, previously static and encapsulated by the SDK, now needs to be obtained from your user or generated by you.

You can utilize the new method available in the SDK to incorporate this reference:

```php

withExternalReference(string $reference)

```

This method allows you to pass the external reference as a string parameter.